### PR TITLE
Use after for progress circle updates

### DIFF
--- a/bell.py
+++ b/bell.py
@@ -304,7 +304,7 @@ class IntervalTimerApp:
                 for i in range(steps):
                     if not self.running:
                         break
-                    self.update_circle(i / steps)  # Update progress from 0.0 to 1.0
+                    self.root.after(0, self.update_circle, i / steps)  # Update progress from 0.0 to 1.0
                     time.sleep(update_interval)
                 
                 if self.running:


### PR DESCRIPTION
## Summary
- Schedule progress circle updates using `root.after` so they run on the main Tk thread.

## Testing
- `python -m py_compile bell.py`


------
https://chatgpt.com/codex/tasks/task_e_68931d5822fc8322b1e48c7ca0e762ec